### PR TITLE
Fixed 2.0.1 build

### DIFF
--- a/wscript
+++ b/wscript
@@ -1,0 +1,24 @@
+
+#
+# This file is the default set of rules to compile a Pebble project.
+#
+# Feel free to customize this to your needs.
+#
+
+top = '.'
+out = 'build'
+
+def options(ctx):
+    ctx.load('pebble_sdk')
+
+def configure(ctx):
+    ctx.load('pebble_sdk')
+
+def build(ctx):
+    ctx.load('pebble_sdk')
+
+    ctx.pbl_program(source=ctx.path.ant_glob('src/**/*.c'),
+                    target='pebble-app.elf')
+
+    ctx.pbl_bundle(elf='pebble-app.elf',
+                   js=ctx.path.ant_glob('src/js/**/*.js'))


### PR DESCRIPTION
Added wscript so that a fresh clone of the repo can be built using 'pebble build' out of box with 2.0.1 SDK (before I got an error saying something about the project using an older version and the convert failed).
